### PR TITLE
API v3.1: major version bump and linting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ AllCops:
     - vendor/**/*
     - .*/**
     - spec/fixtures/**/*
-  TargetRubyVersion: 2.2.0
+  TargetRubyVersion: 2.4.0
 
 Style/StringLiterals:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,57 +1,13 @@
-# For all options see https://github.com/bbatsov/rubocop/tree/master/config
-
 AllCops:
-  DisplayCopNames: true
-  Exclude:
-    - vendor/**/*
-    - .*/**
-    - spec/fixtures/**/*
+  NewCops: enable
   TargetRubyVersion: 2.4.0
 
-Style/StringLiterals:
-  Enabled: false
-
-Style/PercentLiteralDelimiters:
-  Enabled: false
-
-Style/Documentation:
-  Enabled: false
-
-Style/SignalException:
-  EnforcedStyle: only_raise
-
-Naming/FileName:
-  Exclude:
-    - Gemfile
-
-Metrics/MethodLength:
-  CountComments: false
-  Max: 25
+Layout/LineLength:
+  Max: 100
 
 Metrics/BlockLength:
   Exclude:
     - spec/**/*
 
-Metrics/AbcSize:
-  Max: 25
-
-# Don't require utf-8 encoding comment
-Style/Encoding:
+Style/Documentation:
   Enabled: false
-
-Metrics/LineLength:
-  Max: 90
-
-Metrics/ClassLength:
-  Enabled: false
-
-Layout/DotPosition:
-  EnforcedStyle: trailing
-
-# Allow class and message or instance raises
-Style/RaiseArgs:
-  Enabled: false
-
-Lint/AmbiguousBlockAssociation:
-  Exclude:
-    - "spec/**/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,3 @@ rvm:
 script:
   - bundle exec rubocop
   - bundle exec rspec spec
-
-# safelist
-branches:
-  only:
-  - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: ruby
-cache: bundler 
+cache: bundler
 
 rvm:
-  - 2.2
-  - 2.3
   - 2.4
   - 2.5
   - 2.6
   - 2.7
+  - 3.0
 
 script:
   - bundle exec rubocop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## v1.2.0, <DATE_TO_GO_HERE>
+## v2.0.0, <DATE_TO_GO_HERE>
 
 - Support Onfido API version 3.1
+- Drop support for Ruby 2.2 and 2.3
 
 ## v1.1.1, 12 March 2021
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 gemspec
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # Onfido
 
-A thin wrapper for Onfido's API.
+The official Ruby library for integrating with the Onfido API.
 
 [![Gem Version](https://badge.fury.io/rb/onfido.svg)](http://badge.fury.io/rb/onfido)
 [![Build Status](https://travis-ci.org/onfido/onfido-ruby.svg?branch=master)](https://travis-ci.org/onfido/onfido-ruby)
 
-This gem supports only `v3` of Onfido's API from version `1.0.0` onwards. The latest version that supports `v2` of Onfido's API is `0.15.0`. `v1` of Onfido's API is deprecated.
-
-The gem is compatible with Ruby 2.2.0 and onwards. Earlier versions of Ruby have [reached end-of-life](https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/), are no longer supported and no longer receive security fixes.
+This version of the gem uses `v3.1` of the Onfido API and is compatible with Ruby 2.4 onwards.
 
 Refer to Onfido's [API documentation](https://documentation.onfido.com) for details of the expected requests and responses.
 
@@ -16,7 +14,7 @@ Refer to Onfido's [API documentation](https://documentation.onfido.com) for deta
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'onfido', '~> 1.2.0'
+gem 'onfido', '~> 2.0.0'
 ```
 
 ## Configuration
@@ -173,8 +171,9 @@ onfido.sdk_token.create(applicant_id: 'applicant_id', referrer: 'referrer') # =>
 ### Error Handling
 
 There are 3 classes of errors raised by the library, all of which subclass `Onfido::OnfidoError`:
+
+- `Onfido::RequestError` is raised whenever Onfido returns a `4xx` response
 - `Onfido::ServerError` is raised whenever Onfido returns a `5xx` response
-- `Onfido::RequestError` is raised whenever Onfido returns any other kind of error
 - `Onfido::ConnectionError` is raised whenever a network error occurs (e.g., a timeout)
 
 All 3 error classes provide the `response_code`, `response_body`, `json_body`, `type` and `fields` of the error (although for `Onfido::ServerError` and `Onfido::ConnectionError` the last 3 are likely to be `nil`).

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,0 @@
-require 'bundler/gem_tasks'

--- a/lib/onfido.rb
+++ b/lib/onfido.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 require 'rack'
 require 'rest-client'

--- a/lib/onfido/api.rb
+++ b/lib/onfido/api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onfido
   class API
     def initialize(options = {})

--- a/lib/onfido/configuration.rb
+++ b/lib/onfido/configuration.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 module Onfido
   module Configuration
     REGION_HOSTS = {
-      us: "api.us.onfido.com",
-      ca: "api.ca.onfido.com"
+      us: 'api.us.onfido.com',
+      ca: 'api.ca.onfido.com'
     }.freeze
 
     attr_accessor :api_key, :region, :open_timeout, :read_timeout
@@ -24,9 +26,7 @@ module Onfido
     end
 
     def logger=(log)
-      unless log.respond_to?(:<<)
-        raise "#{log.class} doesn't seem to behave like a logger!"
-      end
+      raise "#{log.class} doesn't seem to behave like a logger!" unless log.respond_to?(:<<)
 
       RestClient.log = log
     end
@@ -36,10 +36,8 @@ module Onfido
     end
 
     def endpoint
-      region_host = region ? REGION_HOSTS[region.downcase.to_sym] : "api.onfido.com"
-      unless region_host
-        raise "The region \"#{region.downcase}\" is not currently supported"
-      end
+      region_host = region ? REGION_HOSTS[region.downcase.to_sym] : 'api.onfido.com'
+      raise "The region \"#{region.downcase}\" is not currently supported" unless region_host
 
       "https://#{region_host}/v3.1/"
     end

--- a/lib/onfido/errors/connection_error.rb
+++ b/lib/onfido/errors/connection_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onfido
   class ConnectionError < OnfidoError
   end

--- a/lib/onfido/errors/onfido_error.rb
+++ b/lib/onfido/errors/onfido_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onfido
   class OnfidoError < StandardError
     attr_accessor :response_code, :response_body

--- a/lib/onfido/errors/request_error.rb
+++ b/lib/onfido/errors/request_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onfido
   class RequestError < OnfidoError
   end

--- a/lib/onfido/errors/server_error.rb
+++ b/lib/onfido/errors/server_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onfido
   class ServerError < OnfidoError
   end

--- a/lib/onfido/null_logger.rb
+++ b/lib/onfido/null_logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onfido
   class NullLogger
     def <<(*args); end

--- a/lib/onfido/resources/address.rb
+++ b/lib/onfido/resources/address.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onfido
   class Address < Resource
     def all(postcode)

--- a/lib/onfido/resources/applicant.rb
+++ b/lib/onfido/resources/applicant.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onfido
   class Applicant < Resource
     def create(payload)

--- a/lib/onfido/resources/check.rb
+++ b/lib/onfido/resources/check.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onfido
   class Check < Resource
     def create(applicant_id:, report_names:, **payload)

--- a/lib/onfido/resources/document.rb
+++ b/lib/onfido/resources/document.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onfido
   class Document < Resource
     # with open-uri the file can be a link or an actual file

--- a/lib/onfido/resources/extraction.rb
+++ b/lib/onfido/resources/extraction.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onfido
   class Extraction < Resource
     def create(document_id:)

--- a/lib/onfido/resources/live_photo.rb
+++ b/lib/onfido/resources/live_photo.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onfido
   class LivePhoto < Resource
     # with open-uri the file can be a link or an actual file

--- a/lib/onfido/resources/live_video.rb
+++ b/lib/onfido/resources/live_video.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onfido
   class LiveVideo < Resource
     def find(live_video_id)

--- a/lib/onfido/resources/report.rb
+++ b/lib/onfido/resources/report.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onfido
   class Report < Resource
     def find(report_id)

--- a/lib/onfido/resources/sdk_token.rb
+++ b/lib/onfido/resources/sdk_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onfido
   class SdkToken < Resource
     def create(applicant_id:, **payload)

--- a/lib/onfido/resources/webhook.rb
+++ b/lib/onfido/resources/webhook.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onfido
   class Webhook < Resource
     def create(url:, **payload)
@@ -22,8 +24,8 @@ module Onfido
     # request to one computed from the body
     def self.valid?(request_body, request_signature, token)
       if [request_body, request_signature, token].any?(&:nil?)
-        raise ArgumentError, "A request body, request signature and token " \
-                             "must be provided"
+        raise ArgumentError, 'A request body, request signature and token ' \
+                             'must be provided'
       end
 
       computed_signature = generate_signature(request_body, token)

--- a/lib/onfido/version.rb
+++ b/lib/onfido/version.rb
@@ -1,3 +1,3 @@
 module Onfido
-  VERSION = '1.2.0'.freeze
+  VERSION = '2.0.0'.freeze
 end

--- a/lib/onfido/version.rb
+++ b/lib/onfido/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onfido
-  VERSION = '2.0.0'.freeze
+  VERSION = '2.0.0'
 end

--- a/onfido.gemspec
+++ b/onfido.gemspec
@@ -1,4 +1,4 @@
-# coding: utf-8
+# frozen_string_literal: true
 
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
@@ -12,8 +12,8 @@ Gem::Specification.new do |spec|
   spec.summary       = 'A wrapper for Onfido API'
   spec.description   = "A thin wrapper for Onfido's API. This gem only supports "\
                        "v3 of the Onfido API. Refer to Onfido's "\
-                       "API documentation for details of the expected "\
-                       "requests and responses."
+                       'API documentation for details of the expected '\
+                       'requests and responses.'
   spec.homepage      = 'http://github.com/onfido/onfido-ruby'
   spec.license       = 'MIT'
 
@@ -21,11 +21,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_ruby_version = '>= 2.4.0'
 
   spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency 'rspec-its', '~> 1.2'
-  spec.add_development_dependency 'rubocop', '~> 0.57.0'
+  spec.add_development_dependency 'rubocop', '~> 1.11'
   spec.add_development_dependency 'sinatra', '~> 1.4'
   spec.add_development_dependency 'webmock', '~> 3.0'
 

--- a/onfido.gemspec
+++ b/onfido.gemspec
@@ -21,9 +21,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-  spec.required_ruby_version = ">= 2.2.0"
+  spec.required_ruby_version = ">= 2.4.0"
 
-  spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency 'rspec-its', '~> 1.2'
   spec.add_development_dependency 'rubocop', '~> 0.57.0'

--- a/spec/integrations/address_spec.rb
+++ b/spec/integrations/address_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Onfido::Address do
   subject(:api) { Onfido::API.new }
 

--- a/spec/integrations/applicant_spec.rb
+++ b/spec/integrations/applicant_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Onfido::Applicant do
   subject(:applicant) { described_class.new }
   let(:applicant_id) { '61f659cb-c90b-4067-808a-6136b5c01351' }
@@ -30,8 +32,8 @@ describe Onfido::Applicant do
     it 'serializes the payload correctly' do
       WebMock.after_request do |request_signature, _response|
         if request_signature.uri.path == 'v3.1/applicants'
-          expect(Rack::Utils.parse_nested_query(request_signature.body)).
-            to eq(params)
+          expect(Rack::Utils.parse_nested_query(request_signature.body))
+            .to eq(params)
         end
       end
     end
@@ -93,13 +95,13 @@ describe Onfido::Applicant do
       it 'returns an error' do
         applicant_id = 'a2fb9c62-ab10-4898-a8ec-342c4b552ad5'
 
-        expect { applicant.restore(applicant_id) }.to raise_error { |error|
+        expect { applicant.restore(applicant_id) }.to raise_error do |error|
           expect(error).to be_a(Onfido::RequestError)
           expect(error.message).to eq('There was a validation error on this request')
           expect(error.fields).to eq(
-            "Applicant a2fb9c62-ab10-4898-a8ec-342c4b552ad5 is not scheduled for deletion"
+            'Applicant a2fb9c62-ab10-4898-a8ec-342c4b552ad5 is not scheduled for deletion'
           )
-        }
+        end
       end
     end
   end

--- a/spec/integrations/check_spec.rb
+++ b/spec/integrations/check_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Onfido::Check do
   subject(:check) { described_class.new }
   let(:applicant_id) { '61f659cb-c90b-4067-808a-6136b5c01351' }
@@ -20,7 +22,7 @@ describe Onfido::Check do
       expect(response['id']).to eq(check_id)
     end
 
-    it "returns report_ids" do
+    it 'returns report_ids' do
       response = check.find(check_id)
 
       expect(response['report_ids'].first).to be_a(String)
@@ -36,24 +38,24 @@ describe Onfido::Check do
       end
     end
 
-    it "returns report_ids" do
+    it 'returns report_ids' do
       response = check.all(applicant_id)
 
       expect(response['checks'].first['report_ids'].first).to be_a(String)
     end
   end
 
-  describe "#resume" do
+  describe '#resume' do
     it 'returns success response' do
       expect { check.resume(check_id) }.not_to raise_error
     end
   end
 
   describe '#download' do
-  it 'returns the file data' do
-    response = check.download(check_id)
+    it 'returns the file data' do
+      response = check.download(check_id)
 
-    expect(response).not_to be_nil
+      expect(response).not_to be_nil
+    end
   end
-end
 end

--- a/spec/integrations/document_spec.rb
+++ b/spec/integrations/document_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tempfile'
 
 describe Onfido::Document do
@@ -32,8 +34,8 @@ describe Onfido::Document do
       let(:file) { 'https://onfido.com/images/logo.png' }
 
       it 'raises an ArgumentError' do
-        expect { document.create(**params) }.
-          to raise_error(ArgumentError, /must be a `File`-like object/)
+        expect { document.create(**params) }
+          .to raise_error(ArgumentError, /must be a `File`-like object/)
       end
     end
   end

--- a/spec/integrations/exceptions_spec.rb
+++ b/spec/integrations/exceptions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Onfido::Resource do
   let(:resource) { described_class.new }
   let(:api_key) { 'some_key' }
@@ -8,8 +10,8 @@ describe Onfido::Resource do
     it 'raises a custom error' do
       path = '4xx_response'
 
-      expect { resource.get(path: path) }.
-        to raise_error(Onfido::RequestError, 'Something went wrong')
+      expect { resource.get(path: path) }
+        .to raise_error(Onfido::RequestError, 'Something went wrong')
     end
   end
 
@@ -17,8 +19,8 @@ describe Onfido::Resource do
     it 'raises a custom error' do
       path = 'unexpected_error_format'
 
-      expect { resource.get(path: path) }.
-        to raise_error(Onfido::RequestError, /response code was 400/)
+      expect { resource.get(path: path) }
+        .to raise_error(Onfido::RequestError, /response code was 400/)
     end
   end
 
@@ -26,47 +28,47 @@ describe Onfido::Resource do
     it 'raises a server error' do
       path = 'unparseable_response'
 
-      expect { resource.get(path: path) }.
-        to raise_error(Onfido::ServerError, /response code was 504/)
+      expect { resource.get(path: path) }
+        .to raise_error(Onfido::ServerError, /response code was 504/)
     end
   end
 
   context 'timeout' do
     before do
-      allow(RestClient::Request).
-        to receive(:execute).
-        and_raise(RestClient::RequestTimeout)
+      allow(RestClient::Request)
+        .to receive(:execute)
+        .and_raise(RestClient::RequestTimeout)
     end
 
     it 'raises a ConnectionError' do
-      expect { resource.get(path: Onfido.endpoint) }.
-        to raise_error(Onfido::ConnectionError, /Could not connect/)
+      expect { resource.get(path: Onfido.endpoint) }
+        .to raise_error(Onfido::ConnectionError, /Could not connect/)
     end
   end
 
   context 'broken connection' do
     before do
-      allow(RestClient::Request).
-        to receive(:execute).
-        and_raise(RestClient::ServerBrokeConnection)
+      allow(RestClient::Request)
+        .to receive(:execute)
+        .and_raise(RestClient::ServerBrokeConnection)
     end
 
     it 'raises a ConnectionError' do
-      expect { resource.get(path: Onfido.endpoint) }.
-        to raise_error(Onfido::ConnectionError, /connection to the server/)
+      expect { resource.get(path: Onfido.endpoint) }
+        .to raise_error(Onfido::ConnectionError, /connection to the server/)
     end
   end
 
-  context "bad SSL certificate" do
+  context 'bad SSL certificate' do
     before do
-      allow(RestClient::Request).
-        to receive(:execute).
-        and_raise(RestClient::SSLCertificateNotVerified.new(nil))
+      allow(RestClient::Request)
+        .to receive(:execute)
+        .and_raise(RestClient::SSLCertificateNotVerified.new(nil))
     end
 
     it 'raises a ConnectionError' do
-      expect { resource.get(path: Onfido.endpoint) }.
-        to raise_error(Onfido::ConnectionError, /SSL certificate/)
+      expect { resource.get(path: Onfido.endpoint) }
+        .to raise_error(Onfido::ConnectionError, /SSL certificate/)
     end
   end
 end

--- a/spec/integrations/extraction_spec.rb
+++ b/spec/integrations/extraction_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tempfile'
 
 describe Onfido::Extraction do

--- a/spec/integrations/extraction_spec.rb
+++ b/spec/integrations/extraction_spec.rb
@@ -13,7 +13,7 @@ describe Onfido::Extraction do
     end
 
     it 'creates a new extraction' do
-      response = extraction.create(params)
+      response = extraction.create(**params)
 
       expect(response['document_id']).to eq('7568415-123123-123123')
     end

--- a/spec/integrations/live_photo_spec.rb
+++ b/spec/integrations/live_photo_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tempfile'
 
 describe Onfido::LivePhoto do
@@ -25,8 +27,8 @@ describe Onfido::LivePhoto do
       let(:file) { 'https://onfido.com/images/photo.jpg' }
 
       it 'raises an ArgumentError' do
-        expect { live_photo.create(**params) }.
-          to raise_error(ArgumentError, /must be a `File`-like object/)
+        expect { live_photo.create(**params) }
+          .to raise_error(ArgumentError, /must be a `File`-like object/)
       end
     end
   end

--- a/spec/integrations/live_video_spec.rb
+++ b/spec/integrations/live_video_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tempfile'
 
 describe Onfido::LiveVideo do

--- a/spec/integrations/report_spec.rb
+++ b/spec/integrations/report_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Onfido::Report do
   subject(:report) { described_class.new }
   describe '#find' do

--- a/spec/integrations/sdk_token_spec.rb
+++ b/spec/integrations/sdk_token_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Onfido::SdkToken do
   subject(:sdk_token) { described_class.new }
 

--- a/spec/integrations/webhook_spec.rb
+++ b/spec/integrations/webhook_spec.rb
@@ -1,28 +1,30 @@
+# frozen_string_literal: true
+
 describe Onfido::Webhook do
   subject(:webhook) { described_class.new }
 
-  describe "#create" do
+  describe '#create' do
     let(:params) do
       {
-        url: "https://webhookendpoint.url",
+        url: 'https://webhookendpoint.url',
         enabled: true,
         events: [
-          "report.completed",
-          "check.completed"
+          'report.completed',
+          'check.completed'
         ]
       }
     end
 
-    it "creates the webhook" do
+    it 'creates the webhook' do
       response = webhook.create(**params)
 
       expect(response['id']).to_not be_nil
     end
 
-    it "responds with the right url" do
+    it 'responds with the right url' do
       response = webhook.create(**params)
 
-      expect(response["url"]).to eq params[:url]
+      expect(response['url']).to eq params[:url]
     end
   end
 
@@ -36,29 +38,29 @@ describe Onfido::Webhook do
     end
   end
 
-  describe "#destroy" do
-    it "removes the webhook" do
+  describe '#destroy' do
+    it 'removes the webhook' do
       webhook_id = 'fcb73186-0733-4f6f-9c57-d9d5ef979443'
       expect { webhook.destroy(webhook_id) }.not_to raise_error
     end
   end
 
-  describe "#all" do
-    it "returns all the registered webhooks" do
+  describe '#all' do
+    it 'returns all the registered webhooks' do
       response = webhook.all
 
-      expect(response["webhooks"].count).to eq 2
+      expect(response['webhooks'].count).to eq 2
     end
 
-    it "returns with id" do
+    it 'returns with id' do
       response = webhook.all
 
-      expect(response["webhooks"][0]["id"]).to_not be_nil
-      expect(response["webhooks"][1]["id"]).to_not be_nil
+      expect(response['webhooks'][0]['id']).to_not be_nil
+      expect(response['webhooks'][1]['id']).to_not be_nil
     end
   end
 
-  describe ".valid?" do
+  describe '.valid?' do
     subject(:valid?) do
       described_class.valid?(request_body, request_signature, token)
     end
@@ -71,34 +73,34 @@ describe Onfido::Webhook do
 
     it { is_expected.to be(true) }
 
-    context "with an invalid signature" do
+    context 'with an invalid signature' do
       let(:request_signature) do
         's21fd54ew2w1f5d15642132f3d7727ff9a32a7c87072ce514df1f6d3228bec'
       end
       it { is_expected.to be(false) }
     end
 
-    context "with a nil request signature" do
+    context 'with a nil request signature' do
       let(:request_signature) { nil }
       specify { expect { valid? }.to raise_error(ArgumentError) }
     end
 
-    context "with a token other than the one used to sign the request" do
-      let(:token) { "quite_secret_token" }
+    context 'with a token other than the one used to sign the request' do
+      let(:token) { 'quite_secret_token' }
       it { is_expected.to be(false) }
     end
 
-    context "with a nil token" do
+    context 'with a nil token' do
       let(:token) { nil }
       specify { expect { valid? }.to raise_error(ArgumentError) }
     end
 
-    context "with a modified request body" do
+    context 'with a modified request body' do
       let(:request_body) { '{"bar":"baz"}' }
       it { is_expected.to be(false) }
     end
 
-    context "with a nil request body" do
+    context 'with a nil request body' do
       let(:request_body) { nil }
       specify { expect { valid? }.to raise_error(ArgumentError) }
     end

--- a/spec/onfido/api_spec.rb
+++ b/spec/onfido/api_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Onfido::API do
   subject(:api) { described_class.new }
 

--- a/spec/onfido/connection_error_spec.rb
+++ b/spec/onfido/connection_error_spec.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 describe Onfido::ConnectionError do
   subject(:error) do
     described_class.new(
-      "Invalid response object from API",
+      'Invalid response object from API',
       response_code: response_code,
       response_body: response_body
     )
@@ -10,7 +12,7 @@ describe Onfido::ConnectionError do
   let(:response_code) { nil }
   let(:response_body) { nil }
 
-  context "without a response_body" do
+  context 'without a response_body' do
     its(:json_body) { is_expected.to be_nil }
     its(:type) { is_expected.to be_nil }
     its(:fields) { is_expected.to be_nil }

--- a/spec/onfido/request_error_spec.rb
+++ b/spec/onfido/request_error_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Onfido::RequestError do
   subject(:error) do
     described_class.new(
@@ -20,8 +22,8 @@ describe Onfido::RequestError do
   end
 
   it 'returns the right message' do
-    expect { raise error }.
-      to raise_error('Authorization error: please re-check your credentials')
+    expect { raise error }
+      .to raise_error('Authorization error: please re-check your credentials')
   end
 
   its(:type) { is_expected.to eq('authorization_error') }

--- a/spec/onfido/resource_spec.rb
+++ b/spec/onfido/resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'onfido/errors/connection_error'
 
 describe Onfido::Resource do
@@ -26,7 +28,7 @@ describe Onfido::Resource do
   before { allow(Onfido).to receive(:api_key).and_return(api_key) }
 
   describe '#method_missing' do
-    %i(patch).each do |method|
+    %i[patch].each do |method|
       context "for unsupported HTTP method: #{method}" do
         it 'raises an error' do
           expect do
@@ -37,7 +39,7 @@ describe Onfido::Resource do
     end
   end
 
-  describe "API key" do
+  describe 'API key' do
     subject(:resource) { described_class.new(specific_api_key) }
 
     before do
@@ -50,36 +52,36 @@ describe Onfido::Resource do
         timeout: 80
       ).and_call_original
 
-      WebMock.stub_request(:get, url).
-        to_return(body: response.to_json, status: 200)
+      WebMock.stub_request(:get, url)
+             .to_return(body: response.to_json, status: 200)
     end
 
-    context "when using a specific key" do
-      let(:specific_api_key) { "specific_key" }
+    context 'when using a specific key' do
+      let(:specific_api_key) { 'specific_key' }
 
-      it "uses that key when making the request" do
+      it 'uses that key when making the request' do
         resource.get(path: path, payload: payload)
 
         expect(WebMock).to have_requested(:get, url).with(
           headers: {
             'Authorization' => "Token token=#{specific_api_key}",
-            'Accept' => "application/json",
+            'Accept' => 'application/json',
             'User-Agent' => "onfido-ruby/#{Onfido::VERSION}"
           }
         )
       end
     end
 
-    context "when not using a specific key" do
+    context 'when not using a specific key' do
       let(:specific_api_key) { nil }
 
-      it "uses the general config key when making the request" do
+      it 'uses the general config key when making the request' do
         resource.get(path: path, payload: payload)
 
         expect(WebMock).to have_requested(:get, url).with(
           headers: {
             'Authorization' => "Token token=#{api_key}",
-            'Accept' => "application/json",
+            'Accept' => 'application/json',
             'User-Agent' => "onfido-ruby/#{Onfido::VERSION}"
           }
         )
@@ -87,13 +89,13 @@ describe Onfido::Resource do
     end
   end
 
-  describe "valid http methods" do
-    %i(get post put delete).each do |method|
+  describe 'valid http methods' do
+    %i[get post put delete].each do |method|
       context "for supported HTTP method: #{method}" do
-        context "with a success response" do
+        context 'with a success response' do
           before do
-            expect(RestClient::Request).to receive(:execute).
-              with(
+            expect(RestClient::Request).to receive(:execute)
+              .with(
                 url: url,
                 payload: Rack::Utils.build_query(payload),
                 method: method,
@@ -102,29 +104,29 @@ describe Onfido::Resource do
                 timeout: 80
               ).and_call_original
 
-            WebMock.stub_request(method, url).
-              to_return(body: response.to_json,
-                        status: 200,
-                        headers: { "Content-Type" => "application/json" })
+            WebMock.stub_request(method, url)
+                   .to_return(body: response.to_json,
+                              status: 200,
+                              headers: { 'Content-Type' => 'application/json' })
           end
 
           it 'makes a request to an endpoint' do
-            expect(resource.public_send(method, path: path, payload: payload)).
-              to eq(response)
+            expect(resource.public_send(method, path: path, payload: payload))
+              .to eq(response)
           end
         end
 
-        context "with a timeout error response" do
+        context 'with a timeout error response' do
           before do
-            allow_any_instance_of(RestClient::ExceptionWithResponse).
-              to receive(:response).and_return(double(body: "", code: "408"))
-            expect(RestClient::Request).to receive(:execute).
-              and_raise(RestClient::ExceptionWithResponse)
+            allow_any_instance_of(RestClient::ExceptionWithResponse)
+              .to receive(:response).and_return(double(body: '', code: '408'))
+            expect(RestClient::Request).to receive(:execute)
+              .and_raise(RestClient::ExceptionWithResponse)
           end
 
-          it "raises a ConnectionError" do
-            expect { resource.public_send(method, path: path, payload: payload) }.
-              to raise_error(Onfido::ConnectionError)
+          it 'raises a ConnectionError' do
+            expect { resource.public_send(method, path: path, payload: payload) }
+              .to raise_error(Onfido::ConnectionError)
           end
         end
       end

--- a/spec/onfido_spec.rb
+++ b/spec/onfido_spec.rb
@@ -1,26 +1,28 @@
+# frozen_string_literal: true
+
 describe Onfido do
   subject(:onfido) { described_class }
   after(:each) { onfido.reset }
 
   context 'configuration' do
-    describe "default values" do
-      describe ".api_key" do
+    describe 'default values' do
+      describe '.api_key' do
         subject { onfido.api_key }
         it { is_expected.to be_nil }
       end
 
-      describe ".endpoint" do
+      describe '.endpoint' do
         subject { onfido.endpoint }
         it { is_expected.to eq('https://api.onfido.com/v3.1/') }
       end
 
-      describe ".logger" do
+      describe '.logger' do
         subject { onfido.logger }
         it { is_expected.to be_an_instance_of(Onfido::NullLogger) }
       end
     end
 
-    describe "setting an API key" do
+    describe 'setting an API key' do
       it 'changes the configuration to the new value' do
         onfido.api_key = 'some_key'
         expect(onfido.api_key).to eq('some_key')
@@ -44,14 +46,14 @@ describe Onfido do
     describe 'using an unsupported region' do
       it 'should change endpoint' do
         onfido.region = 'de'
-        expect { onfido.endpoint }.
-          to raise_error('The region "de" is not currently supported')
+        expect { onfido.endpoint }
+          .to raise_error('The region "de" is not currently supported')
       end
     end
 
     describe 'using an old API token' do
       it 'should use old endpoint' do
-        onfido.api_key = "live_asdfghjkl1234567890qwertyuiop"
+        onfido.api_key = 'live_asdfghjkl1234567890qwertyuiop'
         expect(onfido.endpoint).to eq('https://api.onfido.com/v3.1/')
       end
     end
@@ -71,8 +73,8 @@ describe Onfido do
           let(:non_logger) { double('NotLogger') }
 
           it 'raises an error' do
-            expect { onfido.logger = non_logger }.
-              to raise_error(
+            expect { onfido.logger = non_logger }
+              .to raise_error(
                 "#{non_logger.class} doesn't seem to behave like a logger!"
               )
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
-Dir[File.dirname(__FILE__).concat("/support/**/*.rb")].each { |f| require f }
+Dir[File.dirname(__FILE__).concat('/support/**/*.rb')].sort.each { |f| require f }
 
 require 'onfido'
 require 'webmock/rspec'

--- a/spec/support/fake_onfido_api.rb
+++ b/spec/support/fake_onfido_api.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require 'sinatra/base'
 
-class FakeOnfidoAPI < Sinatra::Base
+class FakeOnfidoAPI < Sinatra::Base # rubocop:disable Metrics/ClassLength
   get '/v3.1/addresses/pick' do
     json_response(200, 'addresses.json')
   end
@@ -27,7 +29,7 @@ class FakeOnfidoAPI < Sinatra::Base
   end
 
   post '/v3.1/applicants/:id/restore' do
-    if params["id"] == "a2fb9c62-ab10-4898-a8ec-342c4b552ad5"
+    if params['id'] == 'a2fb9c62-ab10-4898-a8ec-342c4b552ad5'
       json_response(422, 'not_scheduled_for_deletion_error.json')
     else
       status 204
@@ -65,10 +67,10 @@ class FakeOnfidoAPI < Sinatra::Base
   end
 
   get '/v3.1/live_photos' do
-    if params["applicant_id"] != "1030303-123123-123123"
-      status 404
-    else
+    if params['applicant_id'] == '1030303-123123-123123'
       json_response(200, 'live_photos.json')
+    else
+      status 404
     end
   end
 
@@ -83,10 +85,10 @@ class FakeOnfidoAPI < Sinatra::Base
   end
 
   get '/v3.1/live_videos' do
-    if params["applicant_id"] != "1030303-123123-123123"
-      status 404
-    else
+    if params['applicant_id'] == '1030303-123123-123123'
       json_response(200, 'live_videos.json')
+    else
+      status 404
     end
   end
 
@@ -97,15 +99,15 @@ class FakeOnfidoAPI < Sinatra::Base
   end
 
   post '/v3.1/checks' do
-    params["applicant_id"].nil? ? status(422) : json_response(201, 'check.json')
+    params['applicant_id'].nil? ? status(422) : json_response(201, 'check.json')
   end
 
   get '/v3.1/checks/:id' do
-    json_response(200, "check.json")
+    json_response(200, 'check.json')
   end
 
   get '/v3.1/checks' do
-    json_response(200, "checks.json")
+    json_response(200, 'checks.json')
   end
 
   post '/v3.1/checks/:id/resume' do
@@ -147,7 +149,7 @@ class FakeOnfidoAPI < Sinatra::Base
   end
 
   delete '/v3.1/webhooks/:id' do
-    content_type "application/json; charset=utf-8"
+    content_type 'application/json; charset=utf-8'
     status 204
   end
 
@@ -172,9 +174,9 @@ class FakeOnfidoAPI < Sinatra::Base
   private
 
   def json_response(response_code, file_name)
-    content_type "application/json; charset=utf-8"
+    content_type 'application/json; charset=utf-8'
     status response_code
-    File.open(File.dirname(__FILE__) + '/fixtures/' + file_name, 'rb').read
+    File.open("#{File.dirname(__FILE__)}/fixtures/#{file_name}", 'rb').read
   end
 
   def pagination_range


### PR DESCRIPTION
One of the commits is just updating rubocop and some of the linting rules - no behaviour changes in that commit.

The main commit is to drop support for ruby 2.2 and 2.3 (and to test support for ruby 3.0) and to add a major version bump.