### PR TITLE
Onfido API : add error coverage for errors RestClient:BadGateway

### DIFF
--- a/lib/onfido/resource.rb
+++ b/lib/onfido/resource.rb
@@ -113,6 +113,9 @@ module Onfido
           "Could not verify Onfido's SSL certificate. Please make sure " \
           'that your network is not intercepting certificates. '
 
+        when RestClient::BadGateway
+          "Could not connect to Onfido. Server may be overloaded." \
+
         when SocketError
           'Unexpected error when trying to connect to Onfido. ' \
           'You may be seeing this message because your DNS is not working. ' \

--- a/spec/integrations/resource_spec.rb
+++ b/spec/integrations/resource_spec.rb
@@ -51,6 +51,19 @@ describe Onfido::Resource do
     end
   end
 
+  context 'RestClient : BadGateway' do
+    before do
+      allow(RestClient::Request)
+        .to receive(:execute)
+        .and_raise(RestClient::BadGateway)
+    end
+
+    it 'raises a ConnectionError' do
+      expect { resource.get(path: '') }
+        .to raise_error(Onfido::ConnectionError, /Could not connect/)
+    end
+  end
+
   context 'broken connection' do
     before do
       allow(RestClient::Request)


### PR DESCRIPTION
As users of the Onfido API, my team and I noticed that the API didn't catch the `RestClient:BadGateway` errors. 

PR objectives: changes to files `resource.rb` and `resource_spec.rb` to catch `RestClient:BadGateway` errors. 