### PR TITLE
Use a valid status in Check fixtures

### DIFF
--- a/spec/support/fixtures/check.json
+++ b/spec/support/fixtures/check.json
@@ -3,7 +3,7 @@
   "created_at": "2019-05-23T13:50:33Z",
   "href": "/v3.4/checks/8546921-123123-123123",
   "applicant_provides_data": "false",
-  "status": "pending",
+  "status": "in_progress",
   "result": "pending",
   "report_ids": [
     "1030303-123123-375629",

--- a/spec/support/fixtures/checks.json
+++ b/spec/support/fixtures/checks.json
@@ -5,7 +5,7 @@
             "created_at": "2019-11-23T13:50:33Z",
             "href": "/v3.4/checks/8546921-123123-123123",
             "applicant_provides_data": "false",
-            "status": "pending",
+            "status": "in_progress",
             "result": "pending",
             "report_ids": [
               "1030303-123123-375629",


### PR DESCRIPTION
Hi 👋🏻 

While creating integration tests for our implementation of this gem, we looked at the `fake_onfido_api` fixtures for inspiration.

I noticed that the `status` property on Check responses does not have a valid value. It's set to `pending`, which according to [the documentation](https://documentation.onfido.com/#check-status) is not a valid Check status.

Seems like an easy fix.