### PR TITLE
Add `Monitor#list_matches`, `#set_match_status`

### DIFF
--- a/lib/onfido/resource.rb
+++ b/lib/onfido/resource.rb
@@ -29,6 +29,10 @@ module Onfido
       handle_request { rest_client[path].put(payload.to_json, ADDITIONAL_HEADERS) }
     end
 
+    def patch(path:, payload: nil)
+      handle_request { rest_client[path].patch(payload.to_json, ADDITIONAL_HEADERS) }
+    end
+
     def delete(path:)
       handle_request { rest_client[path].delete(ADDITIONAL_HEADERS) }
     end

--- a/lib/onfido/resources/monitor.rb
+++ b/lib/onfido/resources/monitor.rb
@@ -20,5 +20,13 @@ module Onfido
     def destroy(monitor_id)
       delete(path: "watchlist_monitors/#{monitor_id}")
     end
+
+    def list_matches(monitor_id)
+      get(path: "watchlist_monitors/#{monitor_id}/matches")
+    end
+
+    def set_match_status(monitor_id, **payload)
+      patch(path: "watchlist_monitors/#{monitor_id}/matches", payload: payload)
+    end
   end
 end

--- a/spec/integrations/monitor_spec.rb
+++ b/spec/integrations/monitor_spec.rb
@@ -34,7 +34,67 @@ describe Onfido::Monitor do
     end
   end
 
-  it 'returns success code' do
-    expect { monitor.destroy(monitor_id) }.not_to raise_error
+  describe '#destroy' do
+    it 'returns success code' do
+      expect { monitor.destroy(monitor_id) }.not_to raise_error
+    end
+  end
+
+  describe '#list_matches' do
+    subject(:list_matches) { monitor.list_matches(monitor_id) }
+
+    it do
+      is_expected
+        .to include('matches' => [hash_including('id' => anything, 'enabled' => true), anything])
+    end
+
+    context 'when the monitor_id does not exist' do
+      let(:monitor_id) { '00000000-c6b8-4c1e-a383-21efa241ce1e' }
+
+      it 'raises an error' do
+        expect { list_matches }.to raise_error(Onfido::RequestError, /404/)
+      end
+    end
+  end
+
+  describe '#set_match_status' do
+    subject(:set_match_status) { monitor.set_match_status(monitor_id, **payload) }
+
+    let(:payload) do
+      {
+        disabled: ['925e47d3-9e21-48d4-b570-9564c4282cec'],
+        enabled: ['37afcacb-5ff0-4b09-831d-5bcc672ca1fb']
+      }
+    end
+
+    it do
+      is_expected
+        .to include('matches' => [hash_including('id' => anything, 'enabled' => true), anything])
+    end
+
+    context 'when a match id is both in enabled and disabled' do
+      before { payload[:disabled] << payload[:enabled][0] }
+
+      it 'raises an error' do
+        expect { set_match_status }
+          .to raise_error(
+            an_instance_of(Onfido::RequestError).and(having_attributes(response_code: 422))
+          )
+      end
+    end
+
+    context 'when not passing any enabled or disabled ids' do
+      let(:payload) { {} }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the monitor_id does not exist' do
+      let(:monitor_id) { '00000000-c6b8-4c1e-a383-21efa241ce1e' }
+
+      it 'raises an error' do
+        expect { set_match_status }.to raise_error(Onfido::RequestError, /404/)
+      end
+    end
   end
 end

--- a/spec/support/fake_onfido_api.rb
+++ b/spec/support/fake_onfido_api.rb
@@ -134,6 +134,31 @@ class FakeOnfidoAPI < Sinatra::Base # rubocop:disable Metrics/ClassLength
     status 204
   end
 
+  get '/v3.5/watchlist_monitors/:monitor_id/matches' do
+    if params['monitor_id'] == '2748c4fc-c6b8-4c1e-a383-21efa241ce1e'
+      json_response(200, 'monitor_matches.json')
+    else
+      status 404
+    end
+  end
+
+  patch '/v3.5/watchlist_monitors/:monitor_id/matches' do
+    if params['monitor_id'] == '2748c4fc-c6b8-4c1e-a383-21efa241ce1e'
+      enabled, disabled = params.values_at('enabled', 'disabled')
+      if enabled&.any? || disabled&.any?
+        if (enabled.to_a & disabled.to_a).any?
+          json_response(422, '4xx_response.json')
+        else
+          json_response(200, 'monitor_matches.json')
+        end
+      else
+        status 204
+      end
+    else
+      status 404
+    end
+  end
+
   get '/v3.5/motion_captures/:id' do
     json_response(200, 'motion_capture.json')
   end

--- a/spec/support/fixtures/monitor_matches.json
+++ b/spec/support/fixtures/monitor_matches.json
@@ -1,0 +1,12 @@
+{
+  "matches": [
+    {
+      "id": "37afcacb-5ff0-4b09-831d-5bcc672ca1fb",
+      "enabled": true
+    },
+    {
+      "id": "925e47d3-9e21-48d4-b570-9564c4282cec",
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
Added support to [List Ongoing Monitoring matches](https://documentation.onfido.com/#list-matches-beta) (`Monitor#list_matches`) and [Set match status](https://documentation.onfido.com/#set-match-status-beta) (`Monitor#set_match_status`) beta endpoints.

If this looks good, please let me know if I should also prepare a release containing these changes.