### PR TITLE
Refresh onfido-ruby after onfido-openapi-spec update (a34b6d8)

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -41,12 +41,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: integration-tests
-    environment: delivery
     if: github.event_name == 'release'
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GH_ACTION_ACCESS_TOKEN }}
       - name: Set up Ruby 2.7
         uses: ruby/setup-ruby@v1
         with:
@@ -62,31 +59,3 @@ jobs:
           gem push *.gem
         env:
           GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"
-      - name: Update CHANGELOG.md
-        run: |
-          TMP_FILE=$(mktemp)
-
-          RELEASE_VERSION=$(jq -r '.release' .release.json)
-          RELEASE_DATE=`date +'%dth %B %Y' | sed -E 's/^0//;s/^([2,3]?)1th/\11st/;s/^([2]?)2th/\12nd/;s/^([2]?)3th/\13rd/'`
-
-          SPEC_COMMIT_SHA=$(jq -r '.source.short_sha' .release.json)
-          SPEC_COMMIT_URL=$(jq -r '.source.repo_url + "/commit/" + .source.long_sha' .release.json)
-          SPEC_RELEASE_VERSION=$(jq -r '.source.version' .release.json)
-          SPEC_RELEASE_URL=$(jq -r '.source.repo_url + "/releases/tag/" + .source.version' .release.json)
-
-          echo -e "# Changelog\n\n## $RELEASE_VERSION $RELEASE_DATE\n\n" >| $TMP_FILE
-          echo -en "${{ github.event.release.body }}\nBased on Onfido OpenAPI spec " >> $TMP_FILE
-
-          if [ -z $SPEC_RELEASE_VERSION ]; then
-            echo "up to commit [$SPEC_COMMIT_SHA](${SPEC_COMMIT_URL})." >> $TMP_FILE
-          else
-            echo "version [$SPEC_RELEASE_VERSION](${SPEC_RELEASE_URL})." >> $TMP_FILE
-          fi
-
-          grep -v "^# Changelog" CHANGELOG.md >> $TMP_FILE
-          mv $TMP_FILE CHANGELOG.md
-
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
-          git commit -m "Update CHANGELOG.md after library release" CHANGELOG.md
-          git push

--- a/.release.json
+++ b/.release.json
@@ -1,9 +1,9 @@
 {
   "source": {
     "repo_url": "https://github.com/onfido/onfido-openapi-spec",
-    "short_sha": "38a8740",
-    "long_sha": "38a87401552386cb0b17aae28385c5e2f4af7bfc",
-    "version": ""
+    "short_sha": "a34b6d8",
+    "long_sha": "a34b6d86714f7f74da2d60a33a76ec3a693d264a",
+    "version": "v3.0.0"
   },
   "release": "v3.0.0"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.0.0 24th June 2024
+
+- Library has been rebuilt from scratch and automatically generated on [Onfido OpenAPI Spec](https://github.com/onfido/onfido-openapi-spec) (release [v3.0.0](https://github.com/onfido/onfido-openapi-spec/releases/tag/v3.0.0))
+- Integration tests have also been implemented
+
 ## v2.9.0 24 November 2023
 
 - Added `signed_evidence_file` method for WorkflowRuns

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This version uses Onfido API v3.6. Refer to our [API versioning guide](https://d
 ### Installation
 
 ```ruby
-gem onfido, '~> 2.0.1'
+gem onfido, '~> 3.0.0'
 ```
 
 Configure with your API token, region and optional timeout (default value is 30):

--- a/lib/onfido/version.rb
+++ b/lib/onfido/version.rb
@@ -11,5 +11,5 @@ Generator version: 7.6.0
 =end
 
 module Onfido
-  VERSION = '1.0.0'
+  VERSION = '3.0.0'
 end


### PR DESCRIPTION
Auto-generated PR with changes till commit onfido/onfido-openapi-spec@a34b6d86714f7f74da2d60a33a76ec3a693d264a (included)

Additional changes:
  - [Update CHANGELOG (and remove step in charge of that from CI for now)](https://github.com/onfido/onfido-ruby/pull/56/commits/cc0ca79547c8c22b6b8b6b81dc245dd1dd157dea)