### PR TITLE
test(webhook): fix tests

### DIFF
--- a/spec/integrations/webhook_spec.rb
+++ b/spec/integrations/webhook_spec.rb
@@ -14,7 +14,7 @@ describe Onfido::Webhook do
     end
 
     let(:webhook) { onfido_api.create_webhook(webhook_builder) }
-    let(:webhook_id) { webhook.id }
+    let!(:webhook_id) { webhook.id }
 
     it 'creates a webhook' do
       expect(webhook).to be_an_instance_of Onfido::Webhook


### PR DESCRIPTION
Fix test failure detected at release time, by forcing webhook creation:

```
Failures:

  1) Onfido::Webhook Webhook lists webhooks
     Failure/Error: expect(list_of_webhooks.webhooks.size).to be > 0

       expected: > 0
            got:   0
     # ./spec/integrations/webhook_spec.rb:42:in `block (3 levels) in <top (required)>'

Finished in 2 minutes 13 seconds (files took 0.62652 seconds to load)
74 examples, 1 failure

Failed examples:

rspec ./spec/integrations/webhook_spec.rb:[38](https://github.com/onfido/onfido-ruby/actions/runs/9988876672/job/27606659679#step:4:39) # Onfido::Webhook Webhook lists webhooks
```

https://github.com/onfido/onfido-ruby/actions/runs/9988876672/job/27606659679