### PR TITLE
Refresh onfido-ruby after onfido-openapi-spec update (54ce45f)

### DIFF
--- a/.release.json
+++ b/.release.json
@@ -1,9 +1,9 @@
 {
   "source": {
     "repo_url": "https://github.com/onfido/onfido-openapi-spec",
-    "short_sha": "964fb43",
-    "long_sha": "964fb43a1bf211197ef7a45c230771b8ba561b3c",
-    "version": "v4.4.0"
+    "short_sha": "54ce45f",
+    "long_sha": "54ce45f2138f044cc5cb40f6904dc7bc1a675be6",
+    "version": "v4.5.0"
   },
-  "release": "v4.4.0"
+  "release": "v4.5.0"
 }

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ group :development, :test do
   gem 'rake', '~> 13.0.1'
   gem 'pry-byebug'
   gem 'rubocop', '~> 0.66.0'
+  gem 'rubyzip', '~> 2.3.2'
 end
 
 gem "faraday-follow_redirects", "~> 0.3.0"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This version uses Onfido API v3.6. Refer to our [API versioning guide](https://d
 ### Installation
 
 ```ruby
-gem onfido, '~> 4.4.0'
+gem onfido, '~> 4.5.0'
 ```
 
 Configure with your API token, region and optional timeout (default value is 30):

--- a/lib/onfido/api/default_api.rb
+++ b/lib/onfido/api/default_api.rb
@@ -943,6 +943,69 @@ module Onfido
       return data, status_code, headers
     end
 
+    # Retrieve Workflow Run Evidence Folder
+    # Retrieves the evidence folder for the designated Workflow Run 
+    # @param workflow_run_id [String] Workflow Run ID
+    # @param [Hash] opts the optional parameters
+    # @return [File]
+    def download_evidence_folder(workflow_run_id, opts = {})
+      data, _status_code, _headers = download_evidence_folder_with_http_info(workflow_run_id, opts)
+      data
+    end
+
+    # Retrieve Workflow Run Evidence Folder
+    # Retrieves the evidence folder for the designated Workflow Run 
+    # @param workflow_run_id [String] Workflow Run ID
+    # @param [Hash] opts the optional parameters
+    # @return [Array<(File, Integer, Hash)>] File data, response status code and response headers
+    def download_evidence_folder_with_http_info(workflow_run_id, opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: DefaultApi.download_evidence_folder ...'
+      end
+      # verify the required parameter 'workflow_run_id' is set
+      if @api_client.config.client_side_validation && workflow_run_id.nil?
+        fail ArgumentError, "Missing the required parameter 'workflow_run_id' when calling DefaultApi.download_evidence_folder"
+      end
+      # resource path
+      local_var_path = '/workflow_runs/{workflow_run_id}/evidence_folder'.sub('{' + 'workflow_run_id' + '}', CGI.escape(workflow_run_id.to_s))
+
+      # query parameters
+      query_params = opts[:query_params] || {}
+
+      # header parameters
+      header_params = opts[:header_params] || {}
+      # HTTP header 'Accept' (if needed)
+      header_params['Accept'] = @api_client.select_header_accept(['application/zip', 'application/json']) unless header_params['Accept']
+
+      # form parameters
+      form_params = opts[:form_params] || {}
+
+      # http body (model)
+      post_body = opts[:debug_body]
+
+      # return_type
+      return_type = opts[:debug_return_type] || 'File'
+
+      # auth_names
+      auth_names = opts[:debug_auth_names] || ['Token']
+
+      new_options = opts.merge(
+        :operation => :"DefaultApi.download_evidence_folder",
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: DefaultApi#download_evidence_folder\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
+
     # Download ID photo
     # ID photos are downloaded using this endpoint.
     # @param id_photo_id [String] The ID photo&#39;s unique identifier.

--- a/lib/onfido/api_client.rb
+++ b/lib/onfido/api_client.rb
@@ -34,7 +34,7 @@ module Onfido
     # @option config [Configuration] Configuration for initializing the object, default to Configuration.default
     def initialize(config = Configuration.default)
       @config = config
-      @user_agent = "onfido-ruby/4.4.0"
+      @user_agent = "onfido-ruby/4.5.0"
       @default_headers = {
         'Content-Type' => 'application/json',
         'User-Agent' => @user_agent

--- a/lib/onfido/version.rb
+++ b/lib/onfido/version.rb
@@ -11,5 +11,5 @@ Generator version: 7.9.0
 =end
 
 module Onfido
-  VERSION = '4.4.0'
+  VERSION = '4.5.0'
 end

--- a/spec/integrations/workflow_run_spec.rb
+++ b/spec/integrations/workflow_run_spec.rb
@@ -79,6 +79,12 @@ describe Onfido::WorkflowRun do
 
         expect(file.size).to be > 0
       end
+
+      it 'downloads evidence folder' do
+        file = onfido_api.download_evidence_folder(workflow_run_id)
+
+        expect(file.size).to be > 0
+      end
     end
   end
 end

--- a/spec/integrations/workflow_run_spec.rb
+++ b/spec/integrations/workflow_run_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../shared_contexts/with_workflow_run'
+require 'zip'
 
 describe Onfido::WorkflowRun do
   describe 'Workflow run' do
@@ -80,10 +81,12 @@ describe Onfido::WorkflowRun do
         expect(file.size).to be > 0
       end
 
-      it 'downloads evidence folder' do
+      it 'downloads an evidence folder' do
         file = onfido_api.download_evidence_folder(workflow_run_id)
 
-        expect(file.size).to be > 0
+        Zip::File.open(file.path) do |zip|
+          expect(zip.entries.size).to be > 0
+        end
       end
     end
   end


### PR DESCRIPTION
Auto-generated PR with changes till commit onfido/onfido-openapi-spec@54ce45f2138f044cc5cb40f6904dc7bc1a675be6 (included)

Additional changes:
  - [Add download_evidence_folder test](https://github.com/onfido/onfido-ruby/pull/72/commits/05b7ec49a9618278353bea622dea876d165f55f3)