### PR TITLE
test: wait for evidence folder to be available

### DIFF
--- a/spec/integrations/report_spec.rb
+++ b/spec/integrations/report_spec.rb
@@ -23,13 +23,15 @@ describe Onfido::Report do
     end
 
     it 'finds a report' do
-      get_document_report = onfido_api.find_report(document_report_id)
+      get_document_report = repeat_request_until_status_changes(Onfido::ReportStatus::COMPLETE) {
+        onfido_api.find_report(document_report_id)
+      }
       get_identity_report = onfido_api.find_report(identity_report_id)
 
       expect(get_document_report).to be_an_instance_of Onfido::DocumentReport
       expect(get_document_report.id).to eq document_report_id
       expect(get_document_report.name).to eq Onfido::ReportName::DOCUMENT
-      expect(get_document_report.status).to eq Onfido::ReportStatus::AWAITING_DATA
+      expect(get_document_report.status).to eq Onfido::ReportStatus::COMPLETE
 
       expect(get_identity_report).to be_an_instance_of Onfido::IdentityEnhancedReport
       expect(get_identity_report.id).to eq identity_report_id

--- a/spec/integrations/workflow_run_spec.rb
+++ b/spec/integrations/workflow_run_spec.rb
@@ -82,7 +82,9 @@ describe Onfido::WorkflowRun do
       end
 
       it 'downloads an evidence folder' do
-        file = onfido_api.download_evidence_folder(workflow_run_id)
+        file = repeat_request_unti_http_code_changes do
+          onfido_api.download_evidence_folder(workflow_run_id)
+        end
 
         Zip::File.open(file.path) do |zip|
           expect(zip.entries.size).to be > 0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,7 +65,7 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 end
 
-def repeat_request_until_status_changes(expected_status, max_retries = 10,
+def repeat_request_until_status_changes(expected_status, max_retries = 15,
   interval = 1, &proc)
   # expected_status --> desired status
   # max_retries     --> how many times to retry the request
@@ -86,7 +86,7 @@ def repeat_request_until_status_changes(expected_status, max_retries = 10,
   instance
 end
 
-def repeat_request_until_task_output_changes(max_retries = 10,
+def repeat_request_until_task_output_changes(max_retries = 15,
   interval = 1, &proc)
   # max_retries     --> how many times to retry the request
   # interval        --> how many seconds to wait until the next retry
@@ -106,7 +106,7 @@ def repeat_request_until_task_output_changes(max_retries = 10,
   instance
 end
 
-def repeat_request_unti_http_code_changes(max_retries = 10,
+def repeat_request_unti_http_code_changes(max_retries = 15,
   interval = 1, &proc)
   # max_retries        --> how many times to retry the request
   # interval           --> how many seconds to wait until the next retry


### PR DESCRIPTION
Evidence folder needs to be available before it can be downloaded. Fix the test by retrying the request until we no longer receive 404.

I also did some extra changes (increasing number of retries) to reduce test flakiness. 