### PR TITLE
Refresh onfido-ruby after onfido-openapi-spec update (5b1da4d)

### DIFF
--- a/.release.json
+++ b/.release.json
@@ -1,9 +1,9 @@
 {
   "source": {
     "repo_url": "https://github.com/onfido/onfido-openapi-spec",
-    "short_sha": "4b15a26",
-    "long_sha": "4b15a26d432dcb9c3788cece0a46b5157b2e8b99",
-    "version": "v5.1.0"
+    "short_sha": "5b1da4d",
+    "long_sha": "5b1da4d39d507af15a2f1fdb322df60e0726c23c",
+    "version": "v5.1.1"
   },
-  "release": "v5.1.0"
+  "release": "v5.1.1"
 }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This version uses Onfido API v3.6. Refer to our [API versioning guide](https://d
 ### Installation
 
 ```ruby
-gem 'onfido', '~> 5.1.0'
+gem 'onfido', '~> 5.1.1'
 ```
 
 Configure with your API token, region and optional timeout (default value is 30):

--- a/lib/onfido/api_client.rb
+++ b/lib/onfido/api_client.rb
@@ -35,7 +35,7 @@ module Onfido
     # @option config [Configuration] Configuration for initializing the object, default to Configuration.default
     def initialize(config = Configuration.default)
       @config = config
-      @user_agent = "onfido-ruby/5.1.0"
+      @user_agent = "onfido-ruby/5.1.1"
       @default_headers = {
         'Content-Type' => 'application/json',
         'User-Agent' => @user_agent
@@ -175,7 +175,7 @@ module Onfido
 
       # reconstruct content
       content = stream.join
-      content = content.unpack('m').join if response.headers['Content-Transfer-Encoding'] == 'binary'
+      content = content.unpack('m').join if response.headers['Content-Transfer-Encoding'] == 'base64'  
       content = content.force_encoding(encoding)
 
       # return byte stream

--- a/lib/onfido/version.rb
+++ b/lib/onfido/version.rb
@@ -11,5 +11,5 @@ Generator version: 7.11.0
 =end
 
 module Onfido
-  VERSION = '5.1.0'
+  VERSION = '5.1.1'
 end


### PR DESCRIPTION
Auto-generated PR with changes till commit onfido/onfido-openapi-spec@5b1da4d39d507af15a2f1fdb322df60e0726c23c (included)

Additional changes:
  - None