### PR TITLE
Refresh onfido-ruby after onfido-openapi-spec update (eb637c7)

### DIFF
--- a/.release.json
+++ b/.release.json
@@ -1,8 +1,8 @@
 {
   "source": {
     "repo_url": "https://github.com/onfido/onfido-openapi-spec",
-    "short_sha": "90238b7",
-    "long_sha": "90238b7dbd5a07f2cbab2813dc8b6478ccd599b4",
+    "short_sha": "eb637c7",
+    "long_sha": "eb637c7ed2ff5a0d217bd6573cb5aed8b41401ab",
     "version": "v5.7.0"
   },
   "release": "v5.7.0"

--- a/lib/onfido/models/document_properties.rb
+++ b/lib/onfido/models/document_properties.rb
@@ -41,6 +41,8 @@ module Onfido
 
     attr_accessor :issuing_date
 
+    attr_accessor :valid_from
+
     attr_accessor :categorisation
 
     attr_accessor :mrz_line1
@@ -143,6 +145,7 @@ module Onfido
         :'nationality' => :'nationality',
         :'issuing_state' => :'issuing_state',
         :'issuing_date' => :'issuing_date',
+        :'valid_from' => :'valid_from',
         :'categorisation' => :'categorisation',
         :'mrz_line1' => :'mrz_line1',
         :'mrz_line2' => :'mrz_line2',
@@ -199,6 +202,7 @@ module Onfido
         :'nationality' => :'String',
         :'issuing_state' => :'String',
         :'issuing_date' => :'Date',
+        :'valid_from' => :'Date',
         :'categorisation' => :'String',
         :'mrz_line1' => :'String',
         :'mrz_line2' => :'String',
@@ -307,6 +311,10 @@ module Onfido
 
       if attributes.key?(:'issuing_date')
         self.issuing_date = attributes[:'issuing_date']
+      end
+
+      if attributes.key?(:'valid_from')
+        self.valid_from = attributes[:'valid_from']
       end
 
       if attributes.key?(:'categorisation')
@@ -511,6 +519,7 @@ module Onfido
           nationality == o.nationality &&
           issuing_state == o.issuing_state &&
           issuing_date == o.issuing_date &&
+          valid_from == o.valid_from &&
           categorisation == o.categorisation &&
           mrz_line1 == o.mrz_line1 &&
           mrz_line2 == o.mrz_line2 &&
@@ -554,7 +563,7 @@ module Onfido
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [date_of_birth, date_of_expiry, personal_number, document_numbers, document_type, first_name, middle_name, last_name, gender, issuing_country, nationality, issuing_state, issuing_date, categorisation, mrz_line1, mrz_line2, mrz_line3, address, place_of_birth, spouse_name, widow_name, alias_name, issuing_authority, remarks, civil_state, expatriation, father_name, mother_name, religion, type_of_permit, version_number, document_subtype, profession, security_document_number, tax_number, nist_identity_evidence_strength, has_issuance_confirmation, real_id_compliance, security_tier, address_lines, barcode, nfc, driving_licence_information, document_classification, extracted_data].hash
+      [date_of_birth, date_of_expiry, personal_number, document_numbers, document_type, first_name, middle_name, last_name, gender, issuing_country, nationality, issuing_state, issuing_date, valid_from, categorisation, mrz_line1, mrz_line2, mrz_line3, address, place_of_birth, spouse_name, widow_name, alias_name, issuing_authority, remarks, civil_state, expatriation, father_name, mother_name, religion, type_of_permit, version_number, document_subtype, profession, security_document_number, tax_number, nist_identity_evidence_strength, has_issuance_confirmation, real_id_compliance, security_tier, address_lines, barcode, nfc, driving_licence_information, document_classification, extracted_data].hash
     end
 
     # Builds the object from hash

--- a/lib/onfido/models/document_with_driver_verification_report_all_of_properties.rb
+++ b/lib/onfido/models/document_with_driver_verification_report_all_of_properties.rb
@@ -41,6 +41,8 @@ module Onfido
 
     attr_accessor :issuing_date
 
+    attr_accessor :valid_from
+
     attr_accessor :categorisation
 
     attr_accessor :mrz_line1
@@ -163,6 +165,7 @@ module Onfido
         :'nationality' => :'nationality',
         :'issuing_state' => :'issuing_state',
         :'issuing_date' => :'issuing_date',
+        :'valid_from' => :'valid_from',
         :'categorisation' => :'categorisation',
         :'mrz_line1' => :'mrz_line1',
         :'mrz_line2' => :'mrz_line2',
@@ -226,6 +229,7 @@ module Onfido
         :'nationality' => :'String',
         :'issuing_state' => :'String',
         :'issuing_date' => :'Date',
+        :'valid_from' => :'Date',
         :'categorisation' => :'String',
         :'mrz_line1' => :'String',
         :'mrz_line2' => :'String',
@@ -348,6 +352,10 @@ module Onfido
 
       if attributes.key?(:'issuing_date')
         self.issuing_date = attributes[:'issuing_date']
+      end
+
+      if attributes.key?(:'valid_from')
+        self.valid_from = attributes[:'valid_from']
       end
 
       if attributes.key?(:'categorisation')
@@ -582,6 +590,7 @@ module Onfido
           nationality == o.nationality &&
           issuing_state == o.issuing_state &&
           issuing_date == o.issuing_date &&
+          valid_from == o.valid_from &&
           categorisation == o.categorisation &&
           mrz_line1 == o.mrz_line1 &&
           mrz_line2 == o.mrz_line2 &&
@@ -632,7 +641,7 @@ module Onfido
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [date_of_birth, date_of_expiry, personal_number, document_numbers, document_type, first_name, middle_name, last_name, gender, issuing_country, nationality, issuing_state, issuing_date, categorisation, mrz_line1, mrz_line2, mrz_line3, address, place_of_birth, spouse_name, widow_name, alias_name, issuing_authority, remarks, civil_state, expatriation, father_name, mother_name, religion, type_of_permit, version_number, document_subtype, profession, security_document_number, tax_number, nist_identity_evidence_strength, has_issuance_confirmation, real_id_compliance, security_tier, address_lines, barcode, nfc, driving_licence_information, document_classification, extracted_data, drivers_licence, restricted_licence, raw_licence_category, raw_vehicle_classes, manual_transmission_restriction, vehicle_class_details, passenger_vehicle].hash
+      [date_of_birth, date_of_expiry, personal_number, document_numbers, document_type, first_name, middle_name, last_name, gender, issuing_country, nationality, issuing_state, issuing_date, valid_from, categorisation, mrz_line1, mrz_line2, mrz_line3, address, place_of_birth, spouse_name, widow_name, alias_name, issuing_authority, remarks, civil_state, expatriation, father_name, mother_name, religion, type_of_permit, version_number, document_subtype, profession, security_document_number, tax_number, nist_identity_evidence_strength, has_issuance_confirmation, real_id_compliance, security_tier, address_lines, barcode, nfc, driving_licence_information, document_classification, extracted_data, drivers_licence, restricted_licence, raw_licence_category, raw_vehicle_classes, manual_transmission_restriction, vehicle_class_details, passenger_vehicle].hash
     end
 
     # Builds the object from hash


### PR DESCRIPTION
Auto-generated PR with changes till commit onfido/onfido-openapi-spec@eb637c7ed2ff5a0d217bd6573cb5aed8b41401ab (included)

Additional changes:
  - None