### PR TITLE
Refresh onfido-ruby after onfido-openapi-spec update (4204f00)

### DIFF
--- a/.release.json
+++ b/.release.json
@@ -3,7 +3,7 @@
     "repo_url": "https://github.com/onfido/onfido-openapi-spec",
     "short_sha": "4204f00",
     "long_sha": "4204f00a2c7f0f5bd61da3b5442d8eb613418e9e",
-    "version": ""
+    "version": "v6.0.0"
   },
   "release": "v6.0.0"
 }

--- a/spec/integrations/workflow_run_spec.rb
+++ b/spec/integrations/workflow_run_spec.rb
@@ -50,7 +50,11 @@ describe Onfido::WorkflowRun do
     end
 
     describe 'downloading evidence file' do
-      let(:file) { onfido_api.download_signed_evidence_file(workflow_run_id) }
+      let(:file) do
+        repeat_request_until_http_code_changes(15, 2) do
+          onfido_api.download_signed_evidence_file(workflow_run_id)
+        end
+      end
 
       it_behaves_like "a valid PDF file", 497605
     end
@@ -76,7 +80,7 @@ describe Onfido::WorkflowRun do
         end
 
         timeline_file_id = onfido_api.create_timeline_file(workflow_run_id).workflow_timeline_file_id
-        file = repeat_request_unti_http_code_changes do
+        file = repeat_request_until_http_code_changes do
           onfido_api.find_timeline_file(workflow_run_id, timeline_file_id)
         end
 
@@ -84,7 +88,7 @@ describe Onfido::WorkflowRun do
       end
 
       it 'downloads an evidence folder' do
-        file = repeat_request_unti_http_code_changes do
+        file = repeat_request_until_http_code_changes(15, 2) do
           onfido_api.download_evidence_folder(workflow_run_id)
         end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -106,7 +106,7 @@ def repeat_request_until_task_output_changes(max_retries = 15,
   instance
 end
 
-def repeat_request_unti_http_code_changes(max_retries = 15,
+def repeat_request_until_http_code_changes(max_retries = 15,
   interval = 1, &proc)
   # max_retries        --> how many times to retry the request
   # interval           --> how many seconds to wait until the next retry


### PR DESCRIPTION
Auto-generated PR with changes till commit onfido/onfido-openapi-spec@4204f00a2c7f0f5bd61da3b5442d8eb613418e9e (included)

Additional changes:
  - [Fix typo in helper function and add retry logic with 30s timeout for evidence file downloads](https://github.com/onfido/onfido-ruby/pull/100/changes/e7ced99825ca99529a2fc78aa916e35c90a93442)