### PR TITLE
Refresh onfido-ruby after onfido-openapi-spec update (6a36202)

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
-      - name: Run integration tests
+      - name: Run integration tests with API token auth
         if: ${{ matrix.ruby-version == '3.2' &&
           github.repository_owner == 'onfido' &&
           (github.event_name == 'pull_request' ||
@@ -40,6 +40,21 @@ jobs:
         run: bundle exec rspec spec
         env:
           ONFIDO_API_TOKEN: ${{ secrets.ONFIDO_API_TOKEN }}
+          ONFIDO_SAMPLE_APPLICANT_ID: ${{ secrets.ONFIDO_SAMPLE_APPLICANT_ID }}
+          ONFIDO_SAMPLE_VIDEO_ID_1: ${{ secrets.ONFIDO_SAMPLE_VIDEO_ID_1 }}
+          ONFIDO_SAMPLE_VIDEO_ID_2: ${{ secrets.ONFIDO_SAMPLE_VIDEO_ID_2 }}
+          ONFIDO_SAMPLE_MOTION_ID_1: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_1 }}
+          ONFIDO_SAMPLE_MOTION_ID_2: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_2 }}
+      - name: Run integration tests with OAuth client credentials auth
+        if: ${{ matrix.ruby-version == '3.2' &&
+          github.repository_owner == 'onfido' &&
+          (github.event_name == 'pull_request' ||
+           github.event_name == 'release' ||
+           github.event_name == 'workflow_dispatch') }}
+        run: bundle exec rspec spec
+        env:
+          ONFIDO_OAUTH_CLIENT_ID: ${{ secrets.ONFIDO_OAUTH_CLIENT_ID }}
+          ONFIDO_OAUTH_CLIENT_SECRET: ${{ secrets.ONFIDO_OAUTH_CLIENT_SECRET }}
           ONFIDO_SAMPLE_APPLICANT_ID: ${{ secrets.ONFIDO_SAMPLE_APPLICANT_ID }}
           ONFIDO_SAMPLE_VIDEO_ID_1: ${{ secrets.ONFIDO_SAMPLE_VIDEO_ID_1 }}
           ONFIDO_SAMPLE_VIDEO_ID_2: ${{ secrets.ONFIDO_SAMPLE_VIDEO_ID_2 }}

--- a/.release.json
+++ b/.release.json
@@ -1,9 +1,9 @@
 {
   "source": {
     "repo_url": "https://github.com/onfido/onfido-openapi-spec",
-    "short_sha": "6a19890",
-    "long_sha": "6a198909828b3935c65b669e44cf2927e84957c0",
-    "version": "v6.0.1"
+    "short_sha": "6a36202",
+    "long_sha": "6a362029f0a58437e8be7185303ef14d3f342feb",
+    "version": "v6.1.0"
   },
-  "release": "v6.1.0"
+  "release": "v6.2.0"
 }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This version uses Onfido API v3.6. Refer to our [API versioning guide](https://d
 ### Installation
 
 ```ruby
-gem 'onfido', '~> 6.1.0'
+gem 'onfido', '~> 6.2.0'
 ```
 
 Configure with your API token, region and optional timeout (default value is 30):
@@ -30,6 +30,22 @@ end
 
 onfido_api = Onfido::DefaultApi.new
 ```
+
+You can also authenticate using OAuth2 client credentials instead of an API token:
+
+```ruby
+require 'onfido'
+
+Onfido.configure do |config|
+  config.set_oauth_credentials(ENV["ONFIDO_OAUTH_CLIENT_ID"], ENV["ONFIDO_OAUTH_CLIENT_SECRET"])
+  config.region = config.region[:EU]
+  config.timeout = 30
+end
+
+onfido_api = Onfido::DefaultApi.new
+```
+
+The client will automatically exchange credentials for an access token and refresh it when it expires.
 
 All resources share the same interface when making API calls. Use `.create` to create a resource, `.find` to find one, and `.all` to fetch all resources.
 

--- a/lib/onfido/api/default_api.rb
+++ b/lib/onfido/api/default_api.rb
@@ -63,7 +63,7 @@ module Onfido
       return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.cancel_report",
@@ -143,7 +143,7 @@ module Onfido
       return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.complete_task",
@@ -211,7 +211,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'Applicant'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.create_applicant",
@@ -279,7 +279,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'Check'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.create_check",
@@ -342,7 +342,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'TimelineFileReference'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.create_timeline_file",
@@ -410,7 +410,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'WatchlistMonitor'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.create_watchlist_monitor",
@@ -478,7 +478,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'Webhook'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.create_webhook",
@@ -546,7 +546,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'WorkflowRun'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.create_workflow_run",
@@ -609,7 +609,7 @@ module Onfido
       return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.delete_applicant",
@@ -678,7 +678,7 @@ module Onfido
       return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.delete_passkey",
@@ -741,7 +741,7 @@ module Onfido
       return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.delete_passkeys",
@@ -804,7 +804,7 @@ module Onfido
       return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.delete_watchlist_monitor",
@@ -867,7 +867,7 @@ module Onfido
       return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.delete_webhook",
@@ -938,7 +938,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'File'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.download_aes_document",
@@ -1001,7 +1001,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'File'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.download_check",
@@ -1064,7 +1064,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'File'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.download_document",
@@ -1127,7 +1127,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'File'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.download_document_video",
@@ -1190,7 +1190,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'File'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.download_evidence_folder",
@@ -1253,7 +1253,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'File'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.download_id_photo",
@@ -1316,7 +1316,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'File'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.download_live_photo",
@@ -1379,7 +1379,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'File'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.download_live_video",
@@ -1442,7 +1442,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'File'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.download_live_video_frame",
@@ -1505,7 +1505,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'File'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.download_motion_capture",
@@ -1568,7 +1568,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'File'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.download_motion_capture_frame",
@@ -1631,7 +1631,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'File'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.download_nfc_face",
@@ -1702,7 +1702,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'File'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.download_qes_document",
@@ -1773,7 +1773,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'File'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.download_ses_document",
@@ -1836,7 +1836,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'File'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.download_signed_evidence_file",
@@ -1899,7 +1899,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'File'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.download_signing_document",
@@ -1967,7 +1967,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'Extraction'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.extract",
@@ -2031,7 +2031,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'AddressesList'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.find_addresses",
@@ -2094,7 +2094,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'Applicant'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.find_applicant",
@@ -2157,7 +2157,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'Array<ApplicantConsent>'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.find_applicant_consents",
@@ -2220,7 +2220,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'Check'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.find_check",
@@ -2283,7 +2283,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'Document'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.find_document",
@@ -2346,7 +2346,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'IdPhoto'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.find_id_photo",
@@ -2409,7 +2409,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'LivePhoto'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.find_live_photo",
@@ -2472,7 +2472,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'LiveVideo'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.find_live_video",
@@ -2535,7 +2535,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'MotionCapture'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.find_motion_capture",
@@ -2604,7 +2604,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'Passkey'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.find_passkey",
@@ -2667,7 +2667,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'Report'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.find_report",
@@ -2730,7 +2730,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'SigningDocument'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.find_signing_document",
@@ -2799,7 +2799,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'Task'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.find_task",
@@ -2868,7 +2868,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'File'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.find_timeline_file",
@@ -2931,7 +2931,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'WatchlistMonitor'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.find_watchlist_monitor",
@@ -2994,7 +2994,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'Webhook'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.find_webhook",
@@ -3057,7 +3057,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'WorkflowRun'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.find_workflow_run",
@@ -3120,7 +3120,7 @@ module Onfido
       return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.force_report_creation_from_watchlist_monitor",
@@ -3188,7 +3188,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'SdkToken'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.generate_sdk_token",
@@ -3254,7 +3254,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'ApplicantsList'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.list_applicants",
@@ -3318,7 +3318,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'ChecksList'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.list_checks",
@@ -3382,7 +3382,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'DocumentsList'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.list_documents",
@@ -3446,7 +3446,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'IdPhotosList'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.list_id_photos",
@@ -3510,7 +3510,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'LivePhotosList'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.list_live_photos",
@@ -3574,7 +3574,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'LiveVideosList'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.list_live_videos",
@@ -3638,7 +3638,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'MotionCapturesList'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.list_motion_captures",
@@ -3701,7 +3701,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'PasskeysList'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.list_passkeys",
@@ -3764,7 +3764,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'RepeatAttemptsList'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.list_repeat_attempts",
@@ -3828,7 +3828,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'ReportsList'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.list_reports",
@@ -3892,7 +3892,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'SigningDocumentsList'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.list_signing_documents",
@@ -3955,7 +3955,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'Array<TaskItem>'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.list_tasks",
@@ -4018,7 +4018,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'WatchlistMonitorMatchesList'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.list_watchlist_monitor_matches",
@@ -4085,7 +4085,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'WatchlistMonitorsList'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.list_watchlist_monitors",
@@ -4142,7 +4142,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'WebhooksList'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.list_webhooks",
@@ -4224,7 +4224,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'Array<WorkflowRun>'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.list_workflow_runs",
@@ -4281,7 +4281,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'String'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.ping",
@@ -4349,7 +4349,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'ResultsFeedback'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.post_results_feedback",
@@ -4417,7 +4417,7 @@ module Onfido
       return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.resend_webhooks",
@@ -4480,7 +4480,7 @@ module Onfido
       return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.restore_applicant",
@@ -4543,7 +4543,7 @@ module Onfido
       return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.resume_check",
@@ -4606,7 +4606,7 @@ module Onfido
       return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.resume_report",
@@ -4680,7 +4680,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'Applicant'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.update_applicant",
@@ -4760,7 +4760,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'Passkey'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.update_passkey",
@@ -4834,7 +4834,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'WatchlistMonitorMatchesList'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.update_watchlist_monitor_match",
@@ -4908,7 +4908,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'Webhook'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.update_webhook",
@@ -5010,7 +5010,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'Document'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.upload_document",
@@ -5078,7 +5078,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'IdPhoto'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.upload_id_photo",
@@ -5149,7 +5149,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'LivePhoto'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.upload_live_photo",
@@ -5225,7 +5225,7 @@ module Onfido
       return_type = opts[:debug_return_type] || 'SigningDocument'
 
       # auth_names
-      auth_names = opts[:debug_auth_names] || ['Token']
+      auth_names = opts[:debug_auth_names] || ['OAuth2ClientCredentials', 'Token']
 
       new_options = opts.merge(
         :operation => :"DefaultApi.upload_signing_document",

--- a/lib/onfido/api_client.rb
+++ b/lib/onfido/api_client.rb
@@ -35,7 +35,7 @@ module Onfido
     # @option config [Configuration] Configuration for initializing the object, default to Configuration.default
     def initialize(config = Configuration.default)
       @config = config
-      @user_agent = "onfido-ruby/6.1.0"
+      @user_agent = "onfido-ruby/6.2.0"
       @default_headers = {
         'Content-Type' => 'application/json',
         'User-Agent' => @user_agent

--- a/lib/onfido/configuration.rb
+++ b/lib/onfido/configuration.rb
@@ -10,6 +10,8 @@ Generator version: 7.16.0
 =end
 
 require 'faraday/follow_redirects'
+require 'uri'
+require 'json'
 
 module Onfido
   class Configuration
@@ -73,6 +75,14 @@ module Onfido
     # Overrides the access_token if set
     # @return [Proc]
     attr_accessor :access_token_getter
+
+    # Defines the OAuth2 client ID for client credentials flow.
+    # @return [String]
+    attr_accessor :oauth_client_id
+
+    # Defines the OAuth2 client secret for client credentials flow.
+    # @return [String]
+    attr_accessor :oauth_client_secret
 
     # Set this to return data as binary instead of downloading a temp file. When enabled (set to true)
     # HTTP responses with return type `File` will be returned as a stream of binary data.
@@ -188,6 +198,7 @@ module Onfido
       @ignore_operation_servers = false
       @inject_format = false
       @force_ending_format = false
+      @oauth_mutex = Mutex.new 
       @logger = defined?(Rails) ? Rails.logger : Logger.new(STDOUT)
 
       use( Faraday::FollowRedirects::Middleware ) 
@@ -232,6 +243,7 @@ module Onfido
     end
 
     def api_token=(api_token)
+      raise ArgumentError, 'Cannot set API token when OAuth credentials are already configured' if @oauth_client_id 
       @api_key = {'Token' => "Token token=#{api_token}"}
     end
 
@@ -247,6 +259,64 @@ module Onfido
     def timeout=(timeout)
       @timeout = timeout
     end
+
+    # Sets OAuth2 client credentials for authentication.
+    # The client will automatically exchange credentials for an access token
+    # and refresh it when expired. This is mutually exclusive with api_token.
+    #
+    # @param client_id [String] OAuth2 client ID
+    # @param client_secret [String] OAuth2 client secret
+    def set_oauth_credentials(client_id, client_secret)
+      raise ArgumentError, 'OAuth client ID must not be nil or empty' if client_id.nil? || client_id.empty?
+      raise ArgumentError, 'OAuth client secret must not be nil or empty' if client_secret.nil? || client_secret.empty?
+      raise ArgumentError, 'Cannot set OAuth credentials when API token is already configured' if @api_key&.key?('Token') 
+
+      @oauth_client_id = client_id
+      @oauth_client_secret = client_secret
+      @oauth_access_token = nil
+      @oauth_token_expires_at = nil
+    end
+
+    private
+
+    def fetch_oauth_access_token
+      @oauth_mutex.synchronize do
+        return @oauth_access_token if @oauth_access_token && @oauth_token_expires_at && Time.now.to_f < @oauth_token_expires_at
+
+        conn = Faraday.new(
+          url: base_url,
+          ssl: { ca_file: ssl_ca_file, verify: ssl_verify, verify_mode: ssl_verify_mode,
+                 client_cert: ssl_client_cert, client_key: ssl_client_key },
+          proxy: proxy
+        ) do |f|
+          configure_middleware(f)
+          f.adapter(Faraday.default_adapter)
+          configure_connection(f)
+        end
+
+        response = conn.post('oauth/token') do |req|
+          req.headers['Content-Type'] = 'application/x-www-form-urlencoded'
+          req.options.timeout = timeout
+          req.body = URI.encode_www_form(
+            'client_id' => @oauth_client_id,
+            'client_secret' => @oauth_client_secret
+          )
+        end
+
+        unless response.success?
+          raise "OAuth token exchange failed with status #{response.status}: #{response.body}"
+        end
+
+        data = JSON.parse(response.body)
+        @oauth_access_token = data['access_token']
+        expires_in = data['expires_in'].to_i
+        @oauth_token_expires_at = Time.now.to_f + (expires_in - 30)
+
+        @oauth_access_token
+      end
+    end
+
+    public
 
     # Gets API key (with prefix if set).
     # @param [String] param_name the parameter name of API key auth
@@ -273,6 +343,17 @@ module Onfido
 
     # Returns Auth Settings hash for api client.
     def auth_settings
+      if @oauth_client_id && !@oauth_client_id.empty?
+        return {
+          'Token' =>
+            {
+              type: 'bearer',
+              in: 'header',
+              key: 'Authorization',
+              value: "Bearer #{fetch_oauth_access_token}"
+            },
+        }
+      end
       {
         'Token' =>
           {
@@ -280,6 +361,13 @@ module Onfido
             in: 'header',
             key: 'Authorization',
             value: api_key_with_prefix('Token')
+          },
+        'OAuth2ClientCredentials' =>
+          {
+            type: 'oauth2',
+            in: 'header',
+            key: 'Authorization',
+            value: "Bearer #{access_token_with_refresh}"
           },
       }
     end

--- a/lib/onfido/version.rb
+++ b/lib/onfido/version.rb
@@ -11,5 +11,5 @@ Generator version: 7.16.0
 =end
 
 module Onfido
-  VERSION = '6.1.0'
+  VERSION = '6.2.0'
 end

--- a/spec/shared_contexts/with_onfido.rb
+++ b/spec/shared_contexts/with_onfido.rb
@@ -8,7 +8,19 @@ RSpec.shared_context 'with onfido' do
   end
 
   Onfido.configure do |config|
-    config.api_token = ENV['ONFIDO_API_TOKEN']
-    config.region = config.region[:EU]
+    if ENV['ONFIDO_OAUTH_CLIENT_ID'] && !ENV['ONFIDO_OAUTH_CLIENT_ID'].empty?
+      config.set_oauth_credentials(ENV['ONFIDO_OAUTH_CLIENT_ID'], ENV['ONFIDO_OAUTH_CLIENT_SECRET'])
+    else
+      config.api_token = ENV['ONFIDO_API_TOKEN']
+    end
+
+    if ENV['ONFIDO_BASE_PATH'] && !ENV['ONFIDO_BASE_PATH'].empty?
+      uri = URI(ENV['ONFIDO_BASE_PATH'])
+      config.scheme = uri.scheme
+      config.host = uri.host
+      config.base_path = uri.path
+    else
+      config.region = config.region[:EU]
+    end
   end
 end


### PR DESCRIPTION
Auto-generated PR with changes till commit onfido/onfido-openapi-spec@6a362029f0a58437e8be7185303ef14d3f342feb (included)

Additional changes:
  - None